### PR TITLE
ci: fix deprecated artifact actions and stabilize Godot export

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,12 +17,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Setup Godot 4
-           # Pin to a specific version of the composite action to avoid pulling in old dependencies.
-                uses: chickensoft-games/setup-godot@v2.2.0.0
+        # Pin to a specific version of the composite action to avoid pulling in old dependencies.
+        uses: chickensoft-games/setup-godot@v2.2.0
         with:
           version: "4.3"
           use-dotnet: false
@@ -31,11 +30,10 @@ jobs:
       - name: Export HTML5
         run: |
           mkdir -p build/web
-          godot --headless --export-release "Web" build/web/index.html
+          godot --headless --export-release "web" build/web/index.html
 
-      # Only this artifact is needed for Pages:
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v3@
+        uses: actions/upload-pages-artifact@v3
         with:
           path: build/web
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,7 +33,7 @@ jobs:
           godot --headless --export-release "web" build/web/index.html
 
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v2
         with:
           path: build/web
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,7 +21,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Godot 4
-        uses: chickensoft-games/setup-godot@v2
+           # Pin to a specific version of the composite action to avoid pulling in old dependencies.
+                uses: chickensoft-games/setup-godot@v2.2.0.0
         with:
           version: "4.3"
           use-dotnet: false
@@ -34,7 +35,7 @@ jobs:
 
       # Only this artifact is needed for Pages:
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3@
         with:
           path: build/web
 


### PR DESCRIPTION
Use actions/upload-pages-artifact@v3 instead of v2 because v2 depends on the deprecated actions/upload-artifact@v3. Also pin chickensoft-games/setup-godot to v2.2.0 for stability.