### PR TITLE
ci: update upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -39,7 +39,7 @@ jobs:
           Godot_v4.3-stable_linux.x86_64.headless --headless --export-release "Web" build/web/index.html
 
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v2
+        uses:   actions/upload-pages-artifact@v3
         with:
           path: build/web
 

--- a/.github/workflows/pages-min.yml
+++ b/.github/workflows/pages-min.yml
@@ -26,7 +26,7 @@ jobs:
           echo "<!doctype html><title>ping</title><h1>Ping 🌱</h1>" > index.html
           mkdir -p build/web
           cp index.html build/web/index.html
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: build/web
 


### PR DESCRIPTION
Update actions/upload-pages-artifact to v3 to resolve deprecated version error.